### PR TITLE
Support generation of Roslyn SyntaxTree

### DIFF
--- a/IronBlock.Tests/Roslyn/ArithmeticTests.cs
+++ b/IronBlock.Tests/Roslyn/ArithmeticTests.cs
@@ -1,0 +1,110 @@
+using IronBlock.Blocks;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IronBlock.Tests.Roslyn
+{
+    [TestClass]
+    public class ArithmeticTests
+    {
+		[TestMethod]
+		public void Test_Math_Operation_Add()
+		{
+			const string xml = @"
+<xml xmlns=""http://www.w3.org/1999/xhtml"" id=""workspaceBlocks"" style=""display:none"">
+  <variables></variables>
+  <block id=""xYWLO1CBIc?5q]psGz;C"" type=""math_arithmetic"" y=""188"" x=""513"">
+    <field name=""OP"">ADD</field>
+    <value name=""A"">
+      <shadow id=""N;S4N?}[0^h[2J`?IdT-"" type=""math_number"">
+        <field name=""NUM"">2</field>
+      </shadow>
+    </value>
+    <value name=""B"">
+      <shadow id=""w/gZLNCQ3-#qYNhu1o!$"" type=""math_number"">
+        <field name=""NUM"">4</field>
+      </shadow>
+    </value>
+  </block>
+</xml>";
+
+			var output = new Parser()
+				.AddStandardBlocks()
+				.Parse(xml)
+				.Generate();
+
+			string code = output.NormalizeWhitespace().ToFullString();
+			Assert.IsTrue(code.Contains("(2 + 4);"));
+		}
+
+        [TestMethod]
+        public void Test_Math_Operation_Power()
+        {
+            const string xml = @"
+<xml xmlns=""http://www.w3.org/1999/xhtml"" id=""workspaceBlocks"" style=""display:none"">
+  <variables></variables>
+  <block id=""xYWLO1CBIc?5q]psGz;C"" type=""math_arithmetic"" y=""188"" x=""513"">
+    <field name=""OP"">POWER</field>
+    <value name=""A"">
+      <shadow id=""N;S4N?}[0^h[2J`?IdT-"" type=""math_number"">
+        <field name=""NUM"">4</field>
+      </shadow>
+    </value>
+    <value name=""B"">
+      <shadow id=""w/gZLNCQ3-#qYNhu1o!$"" type=""math_number"">
+        <field name=""NUM"">2</field>
+      </shadow>
+    </value>
+  </block>
+</xml>";
+
+            var output = new Parser()
+                .AddStandardBlocks()
+                .Parse(xml)
+                .Generate();
+
+            string code = output.NormalizeWhitespace().ToFullString();
+            Assert.IsTrue(code.Contains("(Math.Pow(4, 2));"));
+        }
+
+        [TestMethod]
+		public void Test_Math_Operation_Add_With_Multiply()
+		{
+			const string xml = @"
+<xml xmlns=""http://www.w3.org/1999/xhtml"" id=""workspaceBlocks"" style=""display:none"">
+  <variables></variables>
+  <block id=""v3etC{34uL,(%l=C)@}j"" type=""math_arithmetic"" y=""213"" x=""538"">
+    <field name=""OP"">MULTIPLY</field>
+    <value name=""A"">
+      <block id=""xYWLO1CBIc?5q]psGz;C"" type=""math_arithmetic"">
+        <field name=""OP"">ADD</field>
+        <value name=""A"">
+          <shadow id=""N;S4N?}[0^h[2J`?IdT-"" type=""math_number"">
+            <field name=""NUM"">2</field>
+          </shadow>
+        </value>
+        <value name=""B"">
+          <shadow id=""w/gZLNCQ3-#qYNhu1o!$"" type=""math_number"">
+            <field name=""NUM"">4</field>
+          </shadow>
+        </value>
+      </block>
+    </value>
+    <value name=""B"">
+      <shadow id=""s_9LSGUgmDr9f.oG-9:_"" type=""math_number"">
+        <field name=""NUM"">5</field>
+      </shadow>
+    </value>
+  </block>
+</xml>";
+
+			var output = new Parser()
+				.AddStandardBlocks()
+				.Parse(xml)
+				.Generate();
+
+			string code = output.NormalizeWhitespace().ToFullString();
+			Assert.IsTrue(code.Contains("((2 + 4) * 5);"));
+		}
+	}
+}

--- a/IronBlock.Tests/Roslyn/VariableTests.cs
+++ b/IronBlock.Tests/Roslyn/VariableTests.cs
@@ -1,0 +1,100 @@
+using IronBlock.Blocks;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IronBlock.Tests.Roslyn
+{
+    [TestClass]
+    public class VariableTests
+    {	
+		[TestMethod]
+		public void Test_Simple_Variable_Assignment()
+		{
+			const string xml = @"
+<xml xmlns=""http://www.w3.org/1999/xhtml"" id=""workspaceBlocks"" style=""display:none"">
+  <variables>
+    <variable id=""CyJvFZf3l6Qz{x[Xx5A^"" type="""">a</variable>
+  </variables>
+  <block id=""ip,}YZWkE^E;?RO+$}w-"" type=""variables_set"" x=""113"" y=""113"">
+    <field id=""CyJvFZf3l6Qz{x[Xx5A^"" name=""VAR"" variabletype="""">a</field>
+    <value name=""VALUE"">
+      <block id=""ufU%[*OmU6UOh}}g`2{Q"" type=""math_number"">
+        <field name=""NUM"">1</field>
+      </block>
+    </value>
+  </block>
+</xml>";
+
+			var output = new Parser()
+				.AddStandardBlocks()
+				.Parse(xml)
+				.Generate();
+
+			string code = output.NormalizeWhitespace().ToFullString();
+			Assert.IsTrue(code.Contains("double a;"));
+			Assert.IsTrue(code.Contains("a = 1;"));
+		}
+
+		[TestMethod]
+		public void Test_Complex_Variable_Assignment()
+		{
+			const string xml = @"
+<xml xmlns=""http://www.w3.org/1999/xhtml"" id=""workspaceBlocks"" style=""display:none"">
+  <variables>
+    <variable id=""CyJvFZf3l6Qz{x[Xx5A^"" type="""">a</variable>
+    <variable id=""/(_We{Fatqdr6G[)kAa@"" type="""">b</variable>
+  </variables>
+  <block id=""ip,}YZWkE^E;?RO+$}w-"" type=""variables_set"" x=""113"" y=""113"">
+    <field id=""CyJvFZf3l6Qz{x[Xx5A^"" name=""VAR"" variabletype="""">a</field>
+    <value name=""VALUE"">
+      <block id=""ufU%[*OmU6UOh}}g`2{Q"" type=""math_number"">
+        <field name=""NUM"">5</field>
+      </block>
+    </value>
+    <next>
+      <block id=""=h.[*kNgW)~s%}yAXEy;"" type=""variables_set"">
+        <field id=""/(_We{Fatqdr6G[)kAa@"" name=""VAR"" variabletype="""">b</field>
+        <value name=""VALUE"">
+          <block id=""2!U:PG=Kv/nZ6cLuDH0i"" type=""math_number"">
+            <field name=""NUM"">8</field>
+          </block>
+        </value>
+        <next>
+          <block id=""Z.^8c:sSI7S9K;9fA~k`"" type=""variables_set"">
+            <field id=""/(_We{Fatqdr6G[)kAa@"" name=""VAR"" variabletype="""">b</field>
+            <value name=""VALUE"">
+              <block id=""WA?c7!*910hd*)m9v|pW"" type=""math_arithmetic"">
+                <field name=""OP"">ADD</field>
+                <value name=""A"">
+                  <block id=""N*XiY,_[6TMlm,3Z1$ur"" type=""variables_get"">
+                    <field id=""CyJvFZf3l6Qz{x[Xx5A^"" name=""VAR"" variabletype="""">a</field>
+                  </block>
+                </value>
+                <value name=""B"">
+                  <block id=""#L_@3{06y1PLH{}OdiU_"" type=""variables_get"">
+                    <field id=""/(_We{Fatqdr6G[)kAa@"" name=""VAR"" variabletype="""">b</field>
+                  </block>
+                </value>
+              </block>
+            </value>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>";
+
+			var output = new Parser()
+				.AddStandardBlocks()
+				.Parse(xml)
+				.Generate();
+
+			string code = output.NormalizeWhitespace().ToFullString();
+			Assert.IsTrue(code.Contains("double a;"));
+			Assert.IsTrue(code.Contains("double b;"));
+			Assert.IsTrue(code.Contains("a = 5;"));
+			Assert.IsTrue(code.Contains("b = 8;"));
+			Assert.IsTrue(code.Contains("b = (a + b);"));
+		}
+	}
+}

--- a/IronBlock/Blocks/ExtensionMethods.cs
+++ b/IronBlock/Blocks/ExtensionMethods.cs
@@ -7,6 +7,7 @@ using IronBlock.Blocks.Variables;
 using IronBlock.Blocks.Controls;
 using IronBlock.Blocks.Logic;
 using IronBlock.Blocks.Lists;
+using Microsoft.CodeAnalysis;
 
 namespace IronBlock.Blocks
 {
@@ -20,7 +21,15 @@ namespace IronBlock.Blocks
             return value.Evaluate(context);
         }
 
-        internal static string Get(this IEnumerable<Field> fields, string name)
+		public static SyntaxNode Generate(this IEnumerable<Value> values, string name, Context context)
+		{
+			var value = values.FirstOrDefault(x => x.Name == name);
+			if (null == value) throw new ArgumentException($"value {name} not found");
+
+			return value.Generate(context);
+		}
+
+		public static string Get(this IEnumerable<Field> fields, string name)
         {
             var field = fields.FirstOrDefault(x => x.Name == name);
             if (null == field) throw new ArgumentException($"field {name} not found");
@@ -43,10 +52,30 @@ namespace IronBlock.Blocks
             return mut.Value;
         }
 
-
         public static object Evaluate(this Workspace workspace)
         {
             return workspace.Evaluate(new Context());
+        }
+
+        public static SyntaxNode Generate(this Workspace workspace)
+		{
+            var context = new Context();
+			return workspace.Generate(context);
+		}
+
+        public static Context GetRootContext(this Context context)
+        {
+            var parentContext = context?.Parent;
+            
+            while (parentContext != null)
+            {
+                if (parentContext.Parent == null)
+                    return parentContext;
+
+                parentContext = parentContext.Parent;
+            };
+
+            return context;
         }
 
         public static Parser AddStandardBlocks(this Parser parser)
@@ -105,10 +134,8 @@ namespace IronBlock.Blocks
             parser.AddBlock<ListsRepeat>("lists_repeat");
             parser.AddBlock<ListsIsEmpty>("lists_isEmpty");
 
-            return parser;
+			return parser;
         }
-
-
     }
 
 }

--- a/IronBlock/Blocks/Math/MathArithmetic.cs
+++ b/IronBlock/Blocks/Math/MathArithmetic.cs
@@ -1,6 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace IronBlock.Blocks.Math
 {
@@ -18,11 +20,70 @@ namespace IronBlock.Blocks.Math
                 case "MULTIPLY": return a * b;
                 case "DIVIDE": return a / b;
                 case "ADD": return a + b;
-                case "SUBTRACT": return a - b;
+                case "MINUS": return a - b;
+                case "POWER": return System.Math.Pow(a, b);
 
                 default: throw new ApplicationException($"Unknown OP {opValue}");
             }
         }
-    }
+
+		public override SyntaxNode Generate(Context context)
+		{
+			var firstExpression = this.Values.Generate("A", context) as ExpressionSyntax;
+			if (firstExpression == null)
+				throw new ApplicationException($"Unknown expression for value A.");
+
+			var secondExpression = this.Values.Generate("B", context) as ExpressionSyntax;
+			if (secondExpression == null)
+				throw new ApplicationException($"Unknown expression for value B.");
+
+            ExpressionSyntax expression = null;
+
+			var opValue = this.Fields.Get("OP");
+            if (opValue == "POWER")
+            {
+                expression = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName("Math"),
+                        IdentifierName("Pow")
+                    )
+                )
+                .WithArgumentList(
+                    ArgumentList(
+                        SeparatedList<ArgumentSyntax>(
+                            new SyntaxNodeOrToken[]{
+                                Argument(
+                                    firstExpression),
+                                Token(SyntaxKind.CommaToken),
+                                Argument(
+                                    secondExpression)
+                            }
+                        )
+                    )
+                );
+            }
+            else
+            {
+                var binaryOperator = GetBinaryOperator(opValue);
+                expression = BinaryExpression(binaryOperator, firstExpression, secondExpression);
+            }
+			
+			return ParenthesizedExpression(expression);
+		}
+
+		private SyntaxKind GetBinaryOperator(string opValue)
+		{
+			switch (opValue)
+			{
+				case "MULTIPLY": return SyntaxKind.MultiplyExpression;
+				case "DIVIDE": return SyntaxKind.DivideExpression;
+				case "ADD": return SyntaxKind.AddExpression;
+				case "MINUS": return SyntaxKind.SubtractExpression;
+
+                default: throw new ApplicationException($"Unknown OP {opValue}");
+			}
+		}
+	}
 
 }

--- a/IronBlock/Blocks/Math/MathNumber.cs
+++ b/IronBlock/Blocks/Math/MathNumber.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace IronBlock.Blocks.Math
 {
@@ -10,6 +11,14 @@ namespace IronBlock.Blocks.Math
         {
             return double.Parse(this.Fields.Get("NUM"));
         }
-    }
 
+		public override SyntaxNode Generate(Context context)
+		{
+			var value = double.Parse(this.Fields.Get("NUM"));
+			return LiteralExpression(
+				SyntaxKind.NumericLiteralExpression,
+				Literal(value)
+			);
+		}
+	}
 }

--- a/IronBlock/Blocks/Procedures/ProceduresCallNoReturn.cs
+++ b/IronBlock/Blocks/Procedures/ProceduresCallNoReturn.cs
@@ -16,7 +16,7 @@ namespace IronBlock.Blocks.Text
 
             var statement = context.Functions[name];
 
-            var funcContext = new Context();
+            var funcContext = new Context() { Parent = context };
             funcContext.Functions = context.Functions;
             
             var counter = 0;

--- a/IronBlock/Blocks/Procedures/ProceduresCallReturn.cs
+++ b/IronBlock/Blocks/Procedures/ProceduresCallReturn.cs
@@ -16,7 +16,7 @@ namespace IronBlock.Blocks.Text
 
             var statement = context.Functions[name];
 
-            var funcContext = new Context();
+            var funcContext = new Context() { Parent = context };
             funcContext.Functions = context.Functions;
             
             var counter = 0;

--- a/IronBlock/Blocks/Text/Text.cs
+++ b/IronBlock/Blocks/Text/Text.cs
@@ -1,6 +1,6 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace IronBlock.Blocks.Text
 {
@@ -11,6 +11,13 @@ namespace IronBlock.Blocks.Text
             var text = this.Fields.Get("TEXT");
 
             return text;
+        }
+
+        public override SyntaxNode Generate(Context context)
+        {
+            var variableName = this.Fields.Get("TEXT");
+
+            return SyntaxFactory.IdentifierName(variableName);
         }
     }
 

--- a/IronBlock/Blocks/Variables/VariablesGet.cs
+++ b/IronBlock/Blocks/Variables/VariablesGet.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace IronBlock.Blocks.Variables
 {
@@ -11,9 +14,16 @@ namespace IronBlock.Blocks.Variables
             var variableName = this.Fields.Get("VAR");
 
             if (!context.Variables.ContainsKey(variableName)) return null;
-
+			
             return context.Variables[variableName];
         }
-    }
+
+		public override SyntaxNode Generate(Context context)
+		{
+			var variableName = this.Fields.Get("VAR");
+
+			return IdentifierName(variableName);
+		}
+	}
 
 }

--- a/IronBlock/Blocks/Variables/VariablesSet.cs
+++ b/IronBlock/Blocks/Variables/VariablesSet.cs
@@ -1,6 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace IronBlock.Blocks.Variables
 {
@@ -25,6 +27,29 @@ namespace IronBlock.Blocks.Variables
 
             return base.Evaluate(context);
         }
-    }
+
+		public override SyntaxNode Generate(Context context)
+		{
+			var variables = context.Variables;
+
+			var variableName = this.Fields.Get("VAR");
+
+			var valueExpression = this.Values.Generate("VALUE", context) as ExpressionSyntax;
+			if (valueExpression == null)
+				throw new ApplicationException($"Unknown expression for value.");
+
+			variables[variableName] = valueExpression;
+
+			var assignment = AssignmentExpression(
+								SyntaxKind.SimpleAssignmentExpression,
+									IdentifierName(variableName),
+									valueExpression
+								);
+
+			context.Statements.Add(ExpressionStatement(assignment));
+
+			return base.Generate(context);
+		}
+	}
 
 }

--- a/IronBlock/IronBlock.csproj
+++ b/IronBlock/IronBlock.csproj
@@ -14,4 +14,8 @@
     <Version>1.0.1</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Nice work with IronBlock!

It would be nice to see support for generation of a Roslyn SyntaxTree from a Blockly workspace. Since that would give you the power to do so much more, e.g. catch compile-time errors before executing, generating assemblies with actual code in runtime, generating C# or VB .NET, etc.

I started this work as a proof of concept. It should be quite straight forward to implement Roslyn SyntaxNode generation for other blocks as well.

Is this something you are interested in bringing into IronBlock?